### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   security:
+    permissions:
+      contents: read
     name: Security Audit
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/Limeload/mcp-for-database/security/code-scanning/8](https://github.com/Limeload/mcp-for-database/security/code-scanning/8)

The best way to fix this problem is to explicitly set a `permissions` block for the job (or at the workflow root) to constrain the GITHUB_TOKEN to the minimum privileges required for these steps. Since the workflow only inspects code and dependencies, and does not perform any write operations (such as creating issues, comments, releases, or modifying repository contents), it only requires read access to repository contents. Therefore, in `.github/workflows/security.yml`, add `permissions: contents: read` to either the workflow root or under the specific `security` job. The recommended location for this repair is at the job level (line 13), just above `name: Security Audit`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
