### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Limeload/mcp-for-database/security/code-scanning/4](https://github.com/Limeload/mcp-for-database/security/code-scanning/4)

To fix the problem, you should add a `permissions` key limiting the GITHUB_TOKEN privileges to the minimum required for the workflow's tasks. Since the workflow only runs build and check steps (code checkout, dependency installation, build/lint scripts), it does not require any write permissions. The most restrictive and recommended permission set for such workflows is `contents: read`. This can be added either at the root of the workflow (just below `name:` and before `on:`) to apply to all jobs, or inside the individual job (`build`), but it is typical to do so at the workflow root for simplicity. 

Edit the file `.github/workflows/ci.yml`, and insert the following lines after the `name: CI` heading (and before the `on:` block):

```yaml
permissions:
  contents: read
```

No additional libraries or functionality are needed to make this change: it is a pure YAML update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
