### PR TITLE
feat(auth): add JWT-based RBAC and user management (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,36 +48,40 @@ Transform natural language into powerful database queries through an intuitive w
 This repository is participating in **Hacktoberfest 2025**! We welcome contributions from developers of all skill levels. After **15 approved pull requests**, you'll be recognized as a project collaborator!
 
 ## 🎬 Visual Tour
+
 Here are some screenshots/GIF showcasing the features of mcp-for-database:
 
 ### Homepage
+
 <img src="https://github.com/user-attachments/assets/e592c00a-b206-4dc6-aaff-92a462184c11" alt="Main Dashboard ScreenShot" width="800" />
 
-*Central dashboard with high-level metrics and quick actions.*
+_Central dashboard with high-level metrics and quick actions._
 <br>
 
 ### Database Console
+
 <img src="https://github.com/user-attachments/assets/9a183aea-4d75-458a-9fca-62c77f8c0024" alt="Database Console" width="800" />
 
-*Query your database using plain English and view results instantly.*
+_Query your database using plain English and view results instantly._
 <br>
 
 ### Live Demo (GIF)
-   ![mcp-for-gif GIF](https://github.com/user-attachments/assets/54a5ceca-05b6-4e9c-a3eb-6dd58df151c9)
-   <br>
-*An animated demonstration of exploring features of mcp-for-database.*
+
+![mcp-for-gif GIF](https://github.com/user-attachments/assets/54a5ceca-05b6-4e9c-a3eb-6dd58df151c9)
+<br>
+_An animated demonstration of exploring features of mcp-for-database._
 
 ### Database Console in Action (GIF)
-   ![database-console-demo GIF](https://github.com/user-attachments/assets/dd31a131-0a12-49a7-87bd-480e1c764a99)
 
-*Watch how to use natural language to query your database:*
+![database-console-demo GIF](https://github.com/user-attachments/assets/dd31a131-0a12-49a7-87bd-480e1c764a99)
 
-*1. Connect to your preferred database (SQLite/Snowflake)*
+_Watch how to use natural language to query your database:_
 
-*2. Type your query in plain English*
+_1. Connect to your preferred database (SQLite/Snowflake)_
 
-*3. See the results instantly in a formatted table*
+_2. Type your query in plain English_
 
+_3. See the results instantly in a formatted table_
 
 ### Quick Start for Contributors
 

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  createErrorResponse,
+  createSuccessResponse
+} from '@/app/lib/api-response';
+import { getStore } from '@/app/lib/auth/store';
+import { verifyPassword } from '@/app/lib/auth/password';
+import { issueJwt, setSessionCookie } from '@/app/lib/auth/jwt';
+
+const LoginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1)
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { email, password } = LoginSchema.parse(body);
+    const store = await getStore();
+    const user = await store.getUserByEmail(email);
+    if (!user) {
+      return NextResponse.json(
+        createErrorResponse('Invalid credentials', 'AUTH_FAILED'),
+        { status: 401 }
+      );
+    }
+    const ok = verifyPassword(password, user.passwordSalt, user.passwordHash);
+    if (!ok) {
+      return NextResponse.json(
+        createErrorResponse('Invalid credentials', 'AUTH_FAILED'),
+        { status: 401 }
+      );
+    }
+    const token = await issueJwt({
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      tokenVersion: user.tokenVersion
+    });
+    await setSessionCookie(token);
+    return NextResponse.json(
+      createSuccessResponse({
+        user: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role
+        }
+      })
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        createErrorResponse(
+          'Invalid request body',
+          'VALIDATION_ERROR',
+          error.flatten()
+        ),
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(
+      createErrorResponse(
+        error instanceof Error ? error.message : 'Unknown error',
+        'INTERNAL_ERROR'
+      ),
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { createSuccessResponse } from '@/app/lib/api-response';
+import { clearSessionCookie } from '@/app/lib/auth/jwt';
+
+export async function POST() {
+  await clearSessionCookie();
+  return NextResponse.json(createSuccessResponse({ success: true }));
+}

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import {
+  createErrorResponse,
+  createSuccessResponse
+} from '@/app/lib/api-response';
+import { authenticateRequest } from '@/app/lib/auth/authorize';
+
+export async function GET() {
+  const auth = await authenticateRequest();
+  if (!auth.ok) return auth.response;
+  return NextResponse.json(createSuccessResponse({ user: auth.user }));
+}

--- a/app/api/db/test-connection/route.ts
+++ b/app/api/db/test-connection/route.ts
@@ -3,6 +3,7 @@ import {
   createSuccessResponse,
   createErrorResponse
 } from '@/app/lib/api-response';
+import { authorize } from '@/app/lib/auth/authorize';
 
 const MCP_SERVER_URL = process.env.MCP_SERVER_URL || 'http://localhost:8000';
 
@@ -14,6 +15,8 @@ const MCP_SERVER_URL = process.env.MCP_SERVER_URL || 'http://localhost:8000';
  */
 export async function POST(request: NextRequest) {
   try {
+    const auth = await authorize('db:test');
+    if (!auth.ok) return auth.response;
     const body = await request.json();
     const { target } = body || {};
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,7 +1,6 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 
 const serviceStartTime = Date.now();
-
 
 async function checkDatabaseConnection(): Promise<boolean> {
   try {
@@ -11,7 +10,7 @@ async function checkDatabaseConnection(): Promise<boolean> {
       body: JSON.stringify({
         prompt: 'SELECT 1',
         target: 'sqlalchemy'
-      }),
+      })
     });
 
     return res.ok;
@@ -23,23 +22,22 @@ async function checkDatabaseConnection(): Promise<boolean> {
 }
 
 export async function GET() {
-    const startTime = Date.now();
+  const startTime = Date.now();
 
-    const dbConnected = await checkDatabaseConnection();
-    const upTimeInSeconds = Math.floor((Date.now() - serviceStartTime) / 1000);
-    const responseTime = Date.now() - startTime;
+  const dbConnected = await checkDatabaseConnection();
+  const upTimeInSeconds = Math.floor((Date.now() - serviceStartTime) / 1000);
+  const responseTime = Date.now() - startTime;
 
-    const status= dbConnected ? 'healthy' : 'unhealthy'
-    const statusCode = dbConnected ? 200 : 503;
-    
-    const response = {
-        status,
-        upTime: `${upTimeInSeconds}s`,
-        version: '1.0.0',
-        responseTime: `${responseTime}ms`,
-        database: dbConnected ? 'connected' : 'disconnected',
-    };
+  const status = dbConnected ? 'healthy' : 'unhealthy';
+  const statusCode = dbConnected ? 200 : 503;
 
+  const response = {
+    status,
+    upTime: `${upTimeInSeconds}s`,
+    version: '1.0.0',
+    responseTime: `${responseTime}ms`,
+    database: dbConnected ? 'connected' : 'disconnected'
+  };
 
-    return NextResponse.json(response, {status: statusCode});
+  return NextResponse.json(response, { status: statusCode });
 }

--- a/app/api/schema/route.ts
+++ b/app/api/schema/route.ts
@@ -4,6 +4,7 @@ import {
   createSuccessResponse,
   createErrorResponse
 } from '@/app/lib/api-response';
+import { authorize } from '@/app/lib/auth/authorize';
 
 // Cache for schema data (in-memory cache)
 interface SchemaCache {
@@ -381,6 +382,8 @@ function generateMockSchemaData(target: string): SchemaMetadata {
  */
 export async function GET(request: NextRequest) {
   try {
+    const auth = await authorize('schema:read');
+    if (!auth.ok) return auth.response;
     // Get target from query parameters
     const { searchParams } = new URL(request.url);
     const target = searchParams.get('target');
@@ -488,6 +491,8 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
+    const auth = await authorize('schema:manage');
+    if (!auth.ok) return auth.response;
     const body = await request.json();
     const { target, action } = body;
 

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authorize, authenticateRequest } from '@/app/lib/auth/authorize';
+import {
+  createErrorResponse,
+  createSuccessResponse
+} from '@/app/lib/api-response';
+import { getStore } from '@/app/lib/auth/store';
+import { USER_ROLES } from '@/app/types/auth';
+
+const CreateSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+  role: z.enum(USER_ROLES),
+  password: z.string().min(8)
+});
+
+const UpdateSchema = z.object({
+  email: z.string().email().optional(),
+  name: z.string().min(1).optional(),
+  role: z.enum(USER_ROLES).optional(),
+  password: z.string().min(8).optional()
+});
+
+export async function GET() {
+  const auth = await authorize('users:list');
+  if (!auth.ok) return auth.response;
+  const store = await getStore();
+  const users = await store.listUsers();
+  return NextResponse.json(createSuccessResponse({ users }));
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await authorize('users:create');
+  if (!auth.ok) return auth.response;
+  try {
+    const body = await request.json();
+    const input = CreateSchema.parse(body);
+    const store = await getStore();
+    const user = await store.createUser(input);
+    return NextResponse.json(createSuccessResponse({ user }));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        createErrorResponse(
+          'Invalid request body',
+          'VALIDATION_ERROR',
+          error.flatten()
+        ),
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(
+      createErrorResponse('Failed to create user', 'INTERNAL_ERROR'),
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const auth = await authorize('users:update');
+  if (!auth.ok) return auth.response;
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+    if (!id) {
+      return NextResponse.json(
+        createErrorResponse('Missing id', 'VALIDATION_ERROR'),
+        { status: 400 }
+      );
+    }
+    const body = await request.json();
+    const input = UpdateSchema.parse(body);
+    const store = await getStore();
+    const user = await store.updateUser(id, input);
+    await store.bumpTokenVersion(id);
+    return NextResponse.json(createSuccessResponse({ user }));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        createErrorResponse(
+          'Invalid request body',
+          'VALIDATION_ERROR',
+          error.flatten()
+        ),
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(
+      createErrorResponse('Failed to update user', 'INTERNAL_ERROR'),
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await authorize('users:delete');
+  if (!auth.ok) return auth.response;
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+    if (!id) {
+      return NextResponse.json(
+        createErrorResponse('Missing id', 'VALIDATION_ERROR'),
+        { status: 400 }
+      );
+    }
+    const store = await getStore();
+    const ok = await store.deleteUser(id);
+    return NextResponse.json(createSuccessResponse({ deleted: ok }));
+  } catch (error) {
+    return NextResponse.json(
+      createErrorResponse('Failed to delete user', 'INTERNAL_ERROR'),
+      { status: 500 }
+    );
+  }
+}

--- a/app/components/DbConsole.tsx
+++ b/app/components/DbConsole.tsx
@@ -102,7 +102,8 @@ export default function DbConsole() {
   // Load theme preference on mount
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
-    const currentTheme: 'light' | 'dark' = savedTheme === 'dark' ? 'dark' : 'light';
+    const currentTheme: 'light' | 'dark' =
+      savedTheme === 'dark' ? 'dark' : 'light';
     setTheme(currentTheme);
     applyTheme(currentTheme);
   }, []);
@@ -119,7 +120,7 @@ export default function DbConsole() {
    * Handle form submission
    * Calls the API route to execute database query
    */
-const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!prompt.trim()) {
@@ -1565,7 +1566,9 @@ const handleSubmit = async (e: React.FormEvent) => {
                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.972 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                 />
               </svg>
-              <p className="text-lg font-medium text-gray-700 dark:text-gray-300">Loading queries...</p>
+              <p className="text-lg font-medium text-gray-700 dark:text-gray-300">
+                Loading queries...
+              </p>
             </div>
           )}
 

--- a/app/components/DbConsole.tsx
+++ b/app/components/DbConsole.tsx
@@ -906,7 +906,10 @@ export default function DbConsole() {
           </div>
 
           {/* Form */}
-          <form onSubmit={handleSubmit} className="px-4 sm:px-6 lg:px-8 py-4 sm:py-6 lg:py-8 space-y-4 sm:space-y-6 lg:space-y-8">
+          <form
+            onSubmit={handleSubmit}
+            className="px-4 sm:px-6 lg:px-8 py-4 sm:py-6 lg:py-8 space-y-4 sm:space-y-6 lg:space-y-8"
+          >
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 lg:gap-8">
               {/* Query Template Selection */}
               <div className="md:col-span-2 mb-2">
@@ -1077,7 +1080,7 @@ export default function DbConsole() {
                   id="target"
                   value={target}
                   onChange={e => setTarget(e.target.value as DatabaseTarget)}
-                  className="w-full px-3 sm:px-4 py-3 border-2 border-gray-200 dark:border-gray-600 rounded-xl shadow-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition-all duration-200 text-base min-h-[44px]"  
+                  className="w-full px-3 sm:px-4 py-3 border-2 border-gray-200 dark:border-gray-600 rounded-xl shadow-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition-all duration-200 text-base min-h-[44px]"
                   disabled={isLoading}
                 >
                   <option value="sqlalchemy">SQLAlchemy (Python ORM)</option>

--- a/app/globals.css
+++ b/app/globals.css
@@ -330,33 +330,35 @@ body {
 }
 
 /* Light mode overrides for gradient backgrounds */
-.light-mode [class*="from-blue-50"] {
+.light-mode [class*='from-blue-50'] {
   --tw-gradient-from: #ffffff !important;
 }
 
-.light-mode [class*="via-white"] {
+.light-mode [class*='via-white'] {
   --tw-gradient-via: #ffffff !important;
 }
 
-.light-mode [class*="to-indigo-50"] {
+.light-mode [class*='to-indigo-50'] {
   --tw-gradient-to: #ffffff !important;
 }
 
-.light-mode [class*="from-gray-900"] {
+.light-mode [class*='from-gray-900'] {
   --tw-gradient-from: #ffffff !important;
 }
 
-.light-mode [class*="via-gray-800"] {
+.light-mode [class*='via-gray-800'] {
   --tw-gradient-via: #ffffff !important;
 }
 
-.light-mode [class*="to-gray-900"] {
+.light-mode [class*='to-gray-900'] {
   --tw-gradient-to: #ffffff !important;
 }
 
 /* Light mode specific enhancements */
 .light-mode .shadow-xl-modern {
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.05), 0 10px 10px -5px rgba(0, 0, 0, 0.02);
+  box-shadow:
+    0 20px 25px -5px rgba(0, 0, 0, 0.05),
+    0 10px 10px -5px rgba(0, 0, 0, 0.02);
 }
 
 /* Light mode schema display - improve badge visibility */
@@ -449,5 +451,7 @@ body {
 }
 /* Dark mode specific enhancements */
 .dark-mode .shadow-xl-modern {
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+  box-shadow:
+    0 20px 25px -5px rgba(0, 0, 0, 0.3),
+    0 10px 10px -5px rgba(0, 0, 0, 0.2);
 }

--- a/app/learn-more/page.tsx
+++ b/app/learn-more/page.tsx
@@ -24,7 +24,8 @@ export default function LearnMorePage() {
   // Load theme preference on mount
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
-    const currentTheme: 'light' | 'dark' = savedTheme === 'dark' ? 'dark' : 'light';
+    const currentTheme: 'light' | 'dark' =
+      savedTheme === 'dark' ? 'dark' : 'light';
     setTheme(currentTheme);
     applyTheme(currentTheme);
   }, []);
@@ -40,26 +41,44 @@ export default function LearnMorePage() {
   return (
     <>
       {/* Theme Toggle Button */}
-      <button 
-        onClick={toggleTheme} 
+      <button
+        onClick={toggleTheme}
         className="fixed top-6 right-6 z-50 p-3 rounded-full bg-white dark:bg-gray-800 shadow-lg border border-gray-200 dark:border-gray-700 hover:shadow-xl transition-all duration-300 hover:scale-105"
         aria-label={`Current theme: ${theme}. Click to toggle`}
         title={`Current: ${theme === 'light' ? 'Light' : 'Dark'} mode`}
       >
         {theme === 'light' ? (
           // Light mode icon (sun)
-          <svg className="w-5 h-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
+          <svg
+            className="w-5 h-5 text-yellow-500"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+              clipRule="evenodd"
+            />
           </svg>
         ) : (
           // Dark mode icon (moon)
-          <svg className="w-5 h-5 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+          <svg
+            className="w-5 h-5 text-blue-400"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
             <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
           </svg>
         )}
       </button>
 
-      <div className={theme === 'dark' ? 'min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900' : 'min-h-screen bg-gradient-to-br from-white via-white to-white'}>
+      <div
+        className={
+          theme === 'dark'
+            ? 'min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900'
+            : 'min-h-screen bg-gradient-to-br from-white via-white to-white'
+        }
+      >
         {/* Navigation Header */}
         <nav className="relative z-40 w-full px-6 py-4">
           <div className="max-w-7xl mx-auto flex items-center justify-between">
@@ -75,7 +94,13 @@ export default function LearnMorePage() {
 
         {/* Hero Section */}
         <div className="relative overflow-hidden pt-10">
-          <div className={theme === 'dark' ? 'absolute inset-0 bg-gradient-to-r from-blue-400/5 to-purple-400/5' : 'absolute inset-0 bg-gradient-to-r from-blue-600/10 to-purple-600/10'}></div>
+          <div
+            className={
+              theme === 'dark'
+                ? 'absolute inset-0 bg-gradient-to-r from-blue-400/5 to-purple-400/5'
+                : 'absolute inset-0 bg-gradient-to-r from-blue-600/10 to-purple-600/10'
+            }
+          ></div>
           <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div className="text-center">
               <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">

--- a/app/lib/auth/authorize.ts
+++ b/app/lib/auth/authorize.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getSessionToken,
+  verifyJwt,
+  issueJwt,
+  setSessionCookie
+} from '@/app/lib/auth/jwt';
+import { getStore } from '@/app/lib/auth/store';
+import { hasPermission } from '@/app/lib/auth/permissions';
+import { Permission, PublicUser } from '@/app/types/auth';
+import { createErrorResponse } from '@/app/lib/api-response';
+
+export type AuthResult =
+  | {
+      ok: true;
+      user: PublicUser & { tokenVersion: number };
+    }
+  | {
+      ok: false;
+      response: NextResponse;
+    };
+
+export const authenticateRequest = async (): Promise<AuthResult> => {
+  const token = await getSessionToken();
+  if (!token) {
+    // Optional auto-auth mode for development or environments explicitly enabling it
+    const autoAuthEnabled =
+      process.env.AUTO_AUTH === 'true' || process.env.AUTO_AUTH === '1';
+    if (autoAuthEnabled) {
+      try {
+        const store = await getStore();
+        const email = (
+          process.env.DEFAULT_ADMIN_EMAIL || 'admin@example.com'
+        ).toLowerCase();
+        let user = await store.getUserByEmail(email);
+        if (!user) {
+          // Create an admin user if not exists (password only used to initialize)
+          const password = process.env.DEFAULT_ADMIN_PASSWORD || 'admin1234';
+          const created = await store.createUser({
+            email,
+            name: 'Auto Admin',
+            role: 'admin',
+            password
+          });
+          // Re-fetch full user to get tokenVersion
+          user = await store.getUserById(created.id);
+        }
+        if (user) {
+          const tokenJwt = await issueJwt({
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            role: user.role,
+            tokenVersion: user.tokenVersion
+          });
+          await setSessionCookie(tokenJwt);
+          const { id, email: e, name, role } = user;
+          return {
+            ok: true,
+            user: { id, email: e, name, role, tokenVersion: user.tokenVersion }
+          };
+        }
+      } catch {
+        // fall through to standard 401 below
+      }
+    }
+    return {
+      ok: false,
+      response: NextResponse.json(
+        createErrorResponse('Authentication required', 'AUTH_REQUIRED'),
+        { status: 401 }
+      )
+    };
+  }
+
+  try {
+    const payload = await verifyJwt(token);
+    const store = await getStore();
+    const user = await store.getUserById(payload.sub);
+    if (!user) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          createErrorResponse('User not found', 'AUTH_INVALID'),
+          { status: 401 }
+        )
+      };
+    }
+    if (user.tokenVersion !== payload.tokenVersion) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          createErrorResponse('Session revoked', 'AUTH_REVOKED'),
+          { status: 401 }
+        )
+      };
+    }
+    const { id, email, name, role } = user;
+    return {
+      ok: true,
+      user: { id, email, name, role, tokenVersion: user.tokenVersion }
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        createErrorResponse('Invalid token', 'AUTH_INVALID'),
+        { status: 401 }
+      )
+    };
+  }
+};
+
+export const authorize = async (
+  permission: Permission
+): Promise<AuthResult> => {
+  const auth = await authenticateRequest();
+  if (!auth.ok) return auth;
+  if (!hasPermission(auth.user.role, permission)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        createErrorResponse('Forbidden: insufficient permissions', 'FORBIDDEN'),
+        { status: 403 }
+      )
+    };
+  }
+  return auth;
+};

--- a/app/lib/auth/jwt.ts
+++ b/app/lib/auth/jwt.ts
@@ -1,0 +1,79 @@
+import { SignJWT, jwtVerify } from 'jose';
+import { cookies } from 'next/headers';
+import { JwtPayload, PublicUser } from '@/app/types/auth';
+
+const AUTH_COOKIE_NAME = 'mcpdb_session';
+const AUTH_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 8; // 8 hours
+
+function getJwtSecret(): Uint8Array {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET env not set');
+  }
+  return new TextEncoder().encode(secret);
+}
+
+export const issueJwt = async (
+  user: PublicUser & { tokenVersion: number },
+  expiresInSeconds: number = AUTH_COOKIE_MAX_AGE_SECONDS
+): Promise<string> => {
+  const now = Math.floor(Date.now() / 1000);
+  const payload: JwtPayload = {
+    sub: user.id,
+    email: user.email,
+    name: user.name,
+    role: user.role,
+    tokenVersion: user.tokenVersion,
+    iat: now,
+    exp: now + expiresInSeconds
+  };
+
+  return await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt(now)
+    .setExpirationTime(payload.exp)
+    .setSubject(payload.sub)
+    .sign(getJwtSecret());
+};
+
+export const setSessionCookie = async (token: string): Promise<void> => {
+  const cookieStore = await cookies();
+  cookieStore.set(AUTH_COOKIE_NAME, token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: AUTH_COOKIE_MAX_AGE_SECONDS
+  });
+};
+
+export const clearSessionCookie = async (): Promise<void> => {
+  const cookieStore = await cookies();
+  cookieStore.delete(AUTH_COOKIE_NAME);
+};
+
+export const getSessionToken = async (): Promise<string | null> => {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(AUTH_COOKIE_NAME)?.value;
+  return token || null;
+};
+
+export const verifyJwt = async (token: string): Promise<JwtPayload> => {
+  const { payload } = await jwtVerify(token, getJwtSecret());
+  // jose returns Record<string, unknown>; cast after minimal validation
+  const required = [
+    'sub',
+    'email',
+    'name',
+    'role',
+    'tokenVersion',
+    'iat',
+    'exp'
+  ];
+  for (const key of required) {
+    if (!(key in payload)) {
+      throw new Error('Invalid JWT payload');
+    }
+  }
+  return payload as unknown as JwtPayload;
+};

--- a/app/lib/auth/password.ts
+++ b/app/lib/auth/password.ts
@@ -1,0 +1,31 @@
+import crypto from 'crypto';
+
+const PBKDF2_ITERATIONS = 150_000;
+const KEY_LENGTH = 32;
+const DIGEST = 'sha256';
+
+export const generateSalt = (): string =>
+  crypto.randomBytes(16).toString('hex');
+
+export const hashPassword = (password: string, salt: string): string => {
+  const derived = crypto.pbkdf2Sync(
+    password,
+    salt,
+    PBKDF2_ITERATIONS,
+    KEY_LENGTH,
+    DIGEST
+  );
+  return derived.toString('hex');
+};
+
+export const verifyPassword = (
+  password: string,
+  salt: string,
+  hash: string
+): boolean => {
+  const computed = hashPassword(password, salt);
+  return crypto.timingSafeEqual(
+    Buffer.from(hash, 'hex'),
+    Buffer.from(computed, 'hex')
+  );
+};

--- a/app/lib/auth/permissions.ts
+++ b/app/lib/auth/permissions.ts
@@ -1,0 +1,40 @@
+import { Permission, UserRole } from '@/app/types/auth';
+
+/**
+ * Role to permission mapping with a simple hierarchy.
+ */
+const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
+  admin: [
+    'auth:me',
+    'auth:logout',
+    'users:list',
+    'users:create',
+    'users:update',
+    'users:delete',
+    'schema:read',
+    'schema:manage',
+    'db:test',
+    'query:read',
+    'query:write'
+  ],
+  editor: [
+    'auth:me',
+    'auth:logout',
+    'schema:read',
+    'db:test',
+    'query:read',
+    'query:write'
+  ],
+  viewer: ['auth:me', 'auth:logout', 'schema:read', 'db:test', 'query:read']
+};
+
+export const getPermissionsForRole = (role: UserRole): Set<Permission> => {
+  return new Set(ROLE_PERMISSIONS[role]);
+};
+
+export const hasPermission = (
+  role: UserRole,
+  permission: Permission
+): boolean => {
+  return getPermissionsForRole(role).has(permission);
+};

--- a/app/lib/auth/store.ts
+++ b/app/lib/auth/store.ts
@@ -1,0 +1,223 @@
+import { createClient } from 'redis';
+import {
+  CreateUserInput,
+  PublicUser,
+  UpdateUserInput,
+  User
+} from '@/app/types/auth';
+import { generateSalt, hashPassword } from '@/app/lib/auth/password';
+
+type Store = {
+  getUserById: (id: string) => Promise<User | null>;
+  getUserByEmail: (email: string) => Promise<User | null>;
+  listUsers: () => Promise<PublicUser[]>;
+  createUser: (input: CreateUserInput) => Promise<PublicUser>;
+  updateUser: (id: string, input: UpdateUserInput) => Promise<PublicUser>;
+  deleteUser: (id: string) => Promise<boolean>;
+  bumpTokenVersion: (id: string) => Promise<void>;
+};
+
+const inMemoryDb = new Map<string, User>();
+
+function toPublic(user: User): PublicUser {
+  const { id, email, name, role } = user;
+  return { id, email, name, role };
+}
+
+async function initDefaultAdmin(): Promise<void> {
+  if (inMemoryDb.size > 0) return;
+  const adminEmail = process.env.DEFAULT_ADMIN_EMAIL || 'admin@example.com';
+  const adminPassword = process.env.DEFAULT_ADMIN_PASSWORD || 'admin1234';
+  const id = 'u_admin_1';
+  const salt = generateSalt();
+  const passwordHash = hashPassword(adminPassword, salt);
+  inMemoryDb.set(id, {
+    id,
+    email: adminEmail,
+    name: 'Administrator',
+    role: 'admin',
+    passwordHash,
+    passwordSalt: salt,
+    tokenVersion: 0
+  });
+}
+
+async function createRedisClient() {
+  const url = process.env.REDIS_URL;
+  if (!url) return null;
+  const client = createClient({ url });
+  client.on('error', err => {
+    console.error('Redis error:', err);
+  });
+  try {
+    await client.connect();
+    return client;
+  } catch (e) {
+    console.warn('Redis unavailable, using in-memory store');
+    return null;
+  }
+}
+
+let redisClientPromise: ReturnType<typeof createRedisClient> | null = null;
+
+export const getStore = async (): Promise<Store> => {
+  if (!redisClientPromise) {
+    redisClientPromise = createRedisClient();
+  }
+  const client = await redisClientPromise;
+  if (!client) {
+    await initDefaultAdmin();
+    return {
+      getUserById: async id => inMemoryDb.get(id) || null,
+      getUserByEmail: async email => {
+        for (const user of inMemoryDb.values()) {
+          if (user.email.toLowerCase() === email.toLowerCase()) return user;
+        }
+        return null;
+      },
+      listUsers: async () => Array.from(inMemoryDb.values()).map(toPublic),
+      createUser: async input => {
+        const exists = await (async () => {
+          for (const user of inMemoryDb.values()) {
+            if (user.email.toLowerCase() === input.email.toLowerCase())
+              return true;
+          }
+          return false;
+        })();
+        if (exists) throw new Error('User already exists');
+        const id = `u_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        const salt = generateSalt();
+        const passwordHash = hashPassword(input.password, salt);
+        const user: User = {
+          id,
+          email: input.email,
+          name: input.name,
+          role: input.role,
+          passwordHash,
+          passwordSalt: salt,
+          tokenVersion: 0
+        };
+        inMemoryDb.set(id, user);
+        return toPublic(user);
+      },
+      updateUser: async (id, input) => {
+        const existing = inMemoryDb.get(id);
+        if (!existing) throw new Error('User not found');
+        const updated: User = {
+          ...existing,
+          email: input.email ?? existing.email,
+          name: input.name ?? existing.name,
+          role: input.role ?? existing.role
+        };
+        if (input.password) {
+          const salt = generateSalt();
+          updated.passwordSalt = salt;
+          updated.passwordHash = hashPassword(input.password, salt);
+          updated.tokenVersion += 1; // invalidate old sessions
+        }
+        inMemoryDb.set(id, updated);
+        return toPublic(updated);
+      },
+      deleteUser: async id => inMemoryDb.delete(id),
+      bumpTokenVersion: async id => {
+        const u = inMemoryDb.get(id);
+        if (u) {
+          u.tokenVersion += 1;
+          inMemoryDb.set(id, u);
+        }
+      }
+    };
+  }
+
+  // Simple Redis JSON storage per user key (avoid external dependencies)
+  const prefix = 'mcpdb:user:';
+  const getKey = (id: string) => `${prefix}${id}`;
+  const emailIndexKey = 'mcpdb:email:index';
+
+  return {
+    getUserById: async id => {
+      const raw = await client.get(getKey(id));
+      return raw ? (JSON.parse(raw) as User) : null;
+    },
+    getUserByEmail: async email => {
+      const id = await client.hGet(emailIndexKey, email.toLowerCase());
+      if (!id) return null;
+      const raw = await client.get(getKey(id));
+      return raw ? (JSON.parse(raw) as User) : null;
+    },
+    listUsers: async () => {
+      const ids = await client.hKeys(emailIndexKey);
+      const uniqueIds = new Set<string>();
+      for (const key of ids) {
+        const id = await client.hGet(emailIndexKey, key);
+        if (id) uniqueIds.add(id);
+      }
+      const users: PublicUser[] = [];
+      for (const id of uniqueIds) {
+        const raw = await client.get(getKey(id));
+        if (raw) users.push(toPublic(JSON.parse(raw) as User));
+      }
+      return users;
+    },
+    createUser: async input => {
+      const existing = await client.hGet(
+        emailIndexKey,
+        input.email.toLowerCase()
+      );
+      if (existing) throw new Error('User already exists');
+      const id = `u_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const salt = generateSalt();
+      const passwordHash = hashPassword(input.password, salt);
+      const user: User = {
+        id,
+        email: input.email,
+        name: input.name,
+        role: input.role,
+        passwordHash,
+        passwordSalt: salt,
+        tokenVersion: 0
+      };
+      await client.set(getKey(id), JSON.stringify(user));
+      await client.hSet(emailIndexKey, input.email.toLowerCase(), id);
+      return toPublic(user);
+    },
+    updateUser: async (id, input) => {
+      const raw = await client.get(getKey(id));
+      if (!raw) throw new Error('User not found');
+      const existing = JSON.parse(raw) as User;
+      const updated: User = {
+        ...existing,
+        email: input.email ?? existing.email,
+        name: input.name ?? existing.name,
+        role: input.role ?? existing.role
+      };
+      if (input.password) {
+        const salt = generateSalt();
+        updated.passwordSalt = salt;
+        updated.passwordHash = hashPassword(input.password, salt);
+        updated.tokenVersion += 1;
+      }
+      await client.set(getKey(id), JSON.stringify(updated));
+      if (input.email && input.email !== existing.email) {
+        await client.hDel(emailIndexKey, existing.email.toLowerCase());
+        await client.hSet(emailIndexKey, input.email.toLowerCase(), id);
+      }
+      return toPublic(updated);
+    },
+    deleteUser: async id => {
+      const raw = await client.get(getKey(id));
+      if (!raw) return false;
+      const u = JSON.parse(raw) as User;
+      await client.del(getKey(id));
+      await client.hDel(emailIndexKey, u.email.toLowerCase());
+      return true;
+    },
+    bumpTokenVersion: async id => {
+      const raw = await client.get(getKey(id));
+      if (!raw) return;
+      const u = JSON.parse(raw) as User;
+      u.tokenVersion += 1;
+      await client.set(getKey(id), JSON.stringify(u));
+    }
+  };
+};

--- a/app/lib/sql/operation.ts
+++ b/app/lib/sql/operation.ts
@@ -1,0 +1,30 @@
+const WRITE_KEYWORDS = [
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'ALTER',
+  'DROP',
+  'TRUNCATE',
+  'CREATE',
+  'REPLACE',
+  'MERGE',
+  'GRANT',
+  'REVOKE'
+];
+
+export const isWriteQuery = (sql: string): boolean => {
+  const normalized = sql.trim().toUpperCase();
+  for (const kw of WRITE_KEYWORDS) {
+    if (normalized.startsWith(kw + ' ') || normalized.startsWith(kw + '\n')) {
+      return true;
+    }
+  }
+  // Detect multi-statement where any statement is write
+  const statements = normalized
+    .split(';')
+    .map(s => s.trim())
+    .filter(Boolean);
+  return statements.some(stmt =>
+    WRITE_KEYWORDS.some(kw => stmt.startsWith(kw + ' '))
+  );
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,8 @@ export default function HomePage() {
   // Load theme preference on mount
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
-    const currentTheme: 'light' | 'dark' = savedTheme === 'dark' ? 'dark' : 'light';
+    const currentTheme: 'light' | 'dark' =
+      savedTheme === 'dark' ? 'dark' : 'light';
     setTheme(currentTheme);
     applyTheme(currentTheme);
   }, []);
@@ -41,29 +42,53 @@ export default function HomePage() {
   return (
     <>
       {/* Theme Toggle Button */}
-      <button 
-        onClick={toggleTheme} 
+      <button
+        onClick={toggleTheme}
         className="fixed top-6 right-6 z-50 p-3 rounded-full bg-white dark:bg-gray-800 shadow-lg border border-gray-200 dark:border-gray-700 hover:shadow-xl transition-all duration-300 hover:scale-105"
         aria-label={`Current theme: ${theme}. Click to toggle`}
         title={`Current: ${theme === 'light' ? 'Light' : 'Dark'} mode`}
       >
         {theme === 'light' ? (
           // Light mode icon (sun)
-          <svg className="w-5 h-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
+          <svg
+            className="w-5 h-5 text-yellow-500"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+              clipRule="evenodd"
+            />
           </svg>
         ) : (
           // Dark mode icon (moon)
-          <svg className="w-5 h-5 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+          <svg
+            className="w-5 h-5 text-blue-400"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
             <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
           </svg>
         )}
       </button>
 
-      <div className={theme === 'dark' ? 'min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900' : 'min-h-screen bg-gradient-to-br from-white via-white to-white'}>
+      <div
+        className={
+          theme === 'dark'
+            ? 'min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900'
+            : 'min-h-screen bg-gradient-to-br from-white via-white to-white'
+        }
+      >
         {/* Hero Section */}
         <div className="relative overflow-hidden">
-          <div className={theme === 'dark' ? 'absolute inset-0 bg-gradient-to-r from-blue-400/5 to-purple-400/5' : 'absolute inset-0 bg-gradient-to-r from-blue-600/10 to-purple-600/10'}></div>
+          <div
+            className={
+              theme === 'dark'
+                ? 'absolute inset-0 bg-gradient-to-r from-blue-400/5 to-purple-400/5'
+                : 'absolute inset-0 bg-gradient-to-r from-blue-600/10 to-purple-600/10'
+            }
+          ></div>
           <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
             <div className="text-center">
               <h1 className="text-5xl md:text-6xl font-bold text-gray-900 dark:text-white mb-6">

--- a/app/types/auth.ts
+++ b/app/types/auth.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+/**
+ * Auth and RBAC core types
+ */
+
+export const USER_ROLES = ['admin', 'editor', 'viewer'] as const;
+export type UserRole = (typeof USER_ROLES)[number];
+
+export const PERMISSIONS = [
+  'auth:me',
+  'auth:logout',
+  'users:list',
+  'users:create',
+  'users:update',
+  'users:delete',
+  'schema:read',
+  'schema:manage',
+  'db:test',
+  'query:read',
+  'query:write'
+] as const;
+export type Permission = (typeof PERMISSIONS)[number];
+
+export const UserSchema = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  name: z.string().min(1),
+  role: z.enum(USER_ROLES),
+  passwordHash: z.string(),
+  passwordSalt: z.string(),
+  tokenVersion: z.number().int().nonnegative()
+});
+export type User = z.infer<typeof UserSchema>;
+
+export type PublicUser = Pick<User, 'id' | 'email' | 'name' | 'role'>;
+
+export type CreateUserInput = {
+  email: string;
+  name: string;
+  role: UserRole;
+  password: string;
+};
+
+export type UpdateUserInput = Partial<{
+  email: string;
+  name: string;
+  role: UserRole;
+  password: string;
+}>;
+
+export type JwtPayload = {
+  sub: string;
+  email: string;
+  name: string;
+  role: UserRole;
+  tokenVersion: number;
+  iat: number;
+  exp: number;
+};
+
+export type AuthenticatedRequestContext = {
+  user: PublicUser & { tokenVersion: number };
+};

--- a/app/utils/exportUtils.ts
+++ b/app/utils/exportUtils.ts
@@ -47,10 +47,10 @@ export function exportToCSV(
 
   // Combine header and rows
   const csvContent = [header, ...rows].join('\n');
- // Download file
+  // Download file
   downloadFile(csvContent, filename, 'text/csv;charset=utf-8;');
 }
-  /**
+/**
  * Export data as JSON format
  */
 export function exportToJSON(

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Public routes that don't require auth
+const PUBLIC_PATHS = [
+  '/',
+  '/learn-more',
+  '/api/health',
+  '/api/auth/login',
+  '/api/mcp'
+];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  if (PUBLIC_PATHS.some(p => pathname === p || pathname.startsWith(p + '/'))) {
+    return NextResponse.next();
+  }
+
+  // Let API routes handle auth themselves; we only gate app pages
+  if (pathname.startsWith('/api/')) {
+    return NextResponse.next();
+  }
+
+  // For now, allow pages without session check; UI can call /api/auth/me
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next|static|favicon.ico).*)']
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "jose": "^5.10.0",
         "mcp-handler": "^1.0.1",
         "next": "^15.5.4",
         "react": "^19.1.0",
@@ -5239,6 +5240,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prepare": "npm run type-check"
   },
   "dependencies": {
+    "jose": "^5.10.0",
     "mcp-handler": "^1.0.1",
     "next": "^15.5.4",
     "react": "^19.1.0",


### PR DESCRIPTION

- Introduces role-based access control (RBAC) with permissions mapping.
- Implements JWT authentication with httpOnly cookie sessions.
- Adds authorization utilities and enforces permissions on API routes.
- Adds user management API (list/create/update/delete, admin-only).
- Adds minimal optional auto-auth for dev via `AUTO_AUTH`.

### Key Changes

- Server
  - `app/types/auth.ts`: roles, permissions, user types.
  - `app/lib/auth/{jwt,authorize,permissions,password,store}.ts`: auth core, RBAC, storage, hashing.
  - `app/api/auth/{login,logout,me}/route.ts`: auth endpoints.
  - `app/api/users/route.ts`: user CRUD (admin-only).
  - `app/api/schema/route.ts`: requires `schema:read`/`schema:manage`.
  - `app/api/db/test-connection/route.ts`: requires `db:test`.
  - `app/lib/sql/operation.ts`: write-query detection.
  - `app/api/db/[query]/route.ts`: requires `query:read` and `query:write` for writes.
  - `middleware.ts`: optional app middleware baseline (no blocking; routes enforce auth).

### Environment

- Required: `JWT_SECRET`
- Optional: `AUTO_AUTH=true|1`, `DEFAULT_ADMIN_EMAIL`, `DEFAULT_ADMIN_PASSWORD`, `REDIS_URL`

### Testing

1. With `AUTO_AUTH=true`, first API call auto-creates/uses admin and sets a session.
2. Call `/api/auth/me` to verify session.
3. Use `/api/users` (admin), `/api/schema`, `/api/db/test-connection`, and `/api/db/query` to validate RBAC, including write-query restriction.

Closes #18 
